### PR TITLE
Trim HTTP responses from Consul before parsing them as booleans.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+dist: trusty

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "consul-recipes"
 
 organization := "org.dmonix"
-version := "0.3.0"
+version := "0.3.1"
 scalaVersion := "2.12.0"
 crossScalaVersions := Seq("2.11.12", "2.12.0")
 

--- a/src/main/scala/org/dmonix/consul/Consul.scala
+++ b/src/main/scala/org/dmonix/consul/Consul.scala
@@ -112,7 +112,7 @@ class Consul(httpSender:HttpSender) {
 
     httpSender
       .put(s"/kv/${kv.key}"+params, kv.value)
-      .map(_.toBoolean)
+      .map(_.trim.toBoolean)
   }
 
   /**
@@ -194,7 +194,7 @@ class Consul(httpSender:HttpSender) {
 
     httpSender
       .delete("/kv/"+kv.key+params)
-      .map(_.toBoolean)
+      .map(_.trim.toBoolean)
   }
   
 }


### PR DESCRIPTION
When running Consul as stand-alone app (non-docker) or embeddded
in the JVM, the response strings may contain the CR character at
the end, which are removed in this commit.